### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/.nuke
+++ b/.nuke
@@ -1,1 +1,0 @@
-VirtoCommerce.AlgoliaSearchModule.sln

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./build.schema.json",
+  "Solution": "VirtoCommerce.AlgoliaSearchModule.sln"
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?><Project>
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.804.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>

--- a/src/VirtoCommerce.AlgoliaSearchModule.Core/VirtoCommerce.AlgoliaSearchModule.Core.csproj
+++ b/src/VirtoCommerce.AlgoliaSearchModule.Core/VirtoCommerce.AlgoliaSearchModule.Core.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Algolia.Search" Version="7.13.3" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.854.0" />
-        <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.804.0" />
+        <PackageReference Include="Algolia.Search" Version="7.38.2" />
+        
+        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+        <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
     </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AlgoliaSearchModule.Data/VirtoCommerce.AlgoliaSearchModule.Data.csproj
+++ b/src/VirtoCommerce.AlgoliaSearchModule.Data/VirtoCommerce.AlgoliaSearchModule.Data.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <noWarn>1591</noWarn>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -12,7 +12,7 @@
         <SonarQubeTestProject>false</SonarQubeTestProject>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+        
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\VirtoCommerce.AlgoliaSearchModule.Core\VirtoCommerce.AlgoliaSearchModule.Core.csproj" />

--- a/src/VirtoCommerce.AlgoliaSearchModule.Web/VirtoCommerce.AlgoliaSearchModule.Web.csproj
+++ b/src/VirtoCommerce.AlgoliaSearchModule.Web/VirtoCommerce.AlgoliaSearchModule.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>False</IsPackable>
         <OutputType>Library</OutputType>
     </PropertyGroup>

--- a/src/VirtoCommerce.AlgoliaSearchModule.Web/module.manifest
+++ b/src/VirtoCommerce.AlgoliaSearchModule.Web/module.manifest
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <id>VirtoCommerce.AlgoliaSearch</id>
-    <version>3.804.0</version>
+    <version>3.1000.0</version>
     <version-tag />
-    <platformVersion>3.854.0</platformVersion>
+    <platformVersion>3.1002.0</platformVersion>
 
     <apps>
         <app id="algolia_search">
@@ -26,13 +26,13 @@
     <projectUrl>https://github.com/VirtoCommerce/vc-module-algolia-search</projectUrl>
     <iconUrl>Modules/$(VirtoCommerce.AlgoliaSearch)/Content/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <releaseNotes>Update to NET8 and Stable 10 release.</releaseNotes>
-    <copyright>Copyright © 2020 - 2025 Virto Commerce. All rights reserved</copyright>
+    <releaseNotes>Update to NET10 and Stable 14 release.</releaseNotes>
+    <copyright>Copyright © 2020 - 2026 Virto Commerce. All rights reserved</copyright>
     <tags>algolia search</tags>
     <assemblyFile>VirtoCommerce.AlgoliaSearchModule.Web.dll</assemblyFile>
     <moduleType>VirtoCommerce.AlgoliaSearchModule.Web.Module, VirtoCommerce.AlgoliaSearchModule.Web</moduleType>
     <dependencies>
-        <dependency id="VirtoCommerce.Search" version="3.804.0" />
+        <dependency id="VirtoCommerce.Search" version="3.1000.0" />
     </dependencies>
     <groups>
     </groups>

--- a/tests/VirtoCommerce.AlgoliaSearchModule.Tests/VirtoCommerce.AlgoliaSearchModule.Tests.csproj
+++ b/tests/VirtoCommerce.AlgoliaSearchModule.Tests/VirtoCommerce.AlgoliaSearchModule.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is a test project -->
@@ -8,11 +8,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
@@ -21,7 +21,7 @@
     <PackageReference Include="xunit.runner.console" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.804.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.AlgoliaSearchModule.Data\VirtoCommerce.AlgoliaSearchModule.Data.csproj" />


### PR DESCRIPTION
## Description
Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AlgoliaSearch_3.1000.0-pr-5-8b9c.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it upgrades target frameworks and multiple dependency versions (including platform/search module and Algolia SDK), which can introduce build/runtime compatibility issues despite minimal code changes.
> 
> **Overview**
> Updates the module to target `net10.0` across Core/Data/Web and tests, and bumps the module/manifest versioning to the `3.1000.x`/Stable 14 line (including `platformVersion` and Search dependency).
> 
> Refreshes key NuGet dependencies (notably `Algolia.Search`, Virto Commerce Platform/Search packages, and test tooling like `coverlet`/`FluentAssertions`), removes SourceLink package references, and replaces the legacy `.nuke` solution pointer with a `.nuke/parameters.json` configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b9cd766d5ca00e20ecbd245c1458ff87a95d9c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->